### PR TITLE
Add Base64 Image Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Example usage:
 $result = MarkupUtil::getJsonLdFromUrl("http://example.com")
 ```
 
+### Image Conversion 
+
+Your Markdown content might contain image data. This library will call a URL available in it to convert them to Base64 binary Data-URLs.
+
 ## Development
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,13 @@ $result = MarkupUtil::getJsonLdFromUrl("http://example.com")
 
 ### Image Conversion 
 
-Your Markdown content might contain image data. This library will call a URL available in it to convert them to Base64 binary Data-URLs.
+Markup content may contain image data in the form of URLs, where these images are stored. By default, this library will call URLs found in this data and convert the content returned by them to Base64 images. You can modify this behaviour by passing in optional parameters while calling any of the above mentioned methods:
+
+* `$downloadImages` - Default is `true`. If set to `false`, image URLs will no longer be accessed and processed.
+
+* `$downloadTimeout` - Default is `5`. This setting will determine the duration in seconds, after which the retrieval will be aborted.
+
+* `$downloadSize` - Default is `500000`. This will limit the size (in Bytes) of the content downloaded from the source.
 
 ## Development
 ### Installation

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "brick/structured-data": "^0.1.1"
+        "brick/structured-data": "^0.1.1",
+        "psr/log": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26b7aaf1b647ba1ad23d6b1a49edffb9",
+    "content-hash": "c2850381ce1d9915176842cb1da6e735",
     "packages": [
         {
             "name": "brick/structured-data",
@@ -54,6 +54,56 @@
                 "source": "https://github.com/brick/structured-data/tree/0.1.1"
             },
             "time": "2020-12-06T00:36:03+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "sabre/uri",
@@ -1820,5 +1870,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/JsonLdWriter.php
+++ b/src/JsonLdWriter.php
@@ -288,7 +288,7 @@ class JsonLdWriter
     }
 
     protected function convertUrlToBinary($url): ?string {
-        // Check if 
+        // Check if the string is a valid URL.
         if(!filter_var($url, FILTER_VALIDATE_URL)) {
             return null;
         }

--- a/src/MarkupUtil.php
+++ b/src/MarkupUtil.php
@@ -28,15 +28,16 @@ class MarkupUtil
      * Extract any Schema.org markup information found in the URL source as JSON+LD,
      * Microdata (inline) or RDFA. HTML files are retrieved using php curl.
      * 
-     * @param string $source A string representation of the URL under which the HTML
-     *                       that is to be scanned is located.
-     * @param bool $downloadImages  Use file_get_contents to retreive and convert
-     *                              images found in the markup data to Base64. IF
-     *                              the image could not be retreived, the original
-     *                              URL is returned.
-     * @param int $downloadTimeout  Time in seconds, after which a download will be
-     *                              aborted.
-     * @param int $downloadSize Maximum size in bytes of images when downloading.
+     * @param string $source          A string representation of the URL under which
+     *                                the HTML that is to be scanned is located.
+     * @param bool   $downloadImages  Use file_get_contents to retreive and convert
+     *                                images found in the markup data to Base64. IF
+     *                                the image could not be retreived, the
+     *                                original URL is returned.
+     * @param int    $downloadTimeout Time in seconds, after which a download will be
+     *                                aborted.
+     * @param int    $downloadSize    Maximum size in bytes of images when
+     *                                downloading.
      * 
      * @return string $result A JSON string containing any markup located in the
      * source. If the source contains multiple markup tags, multiple formats of
@@ -51,25 +52,33 @@ class MarkupUtil
     ) {
         $html = self::getHtmlFromURL($source);
 
-        return self::getJsonLdFromHtmlString($html, $source, $downloadImages, $downloadTimeout, $downloadSize);
+        return self::getJsonLdFromHtmlString(
+            $html,
+            $source,
+            $downloadImages,
+            $downloadTimeout,
+            $downloadSize
+        );
     }
 
     /**
      * Extract any Schema.org markup information found in the file source as JSON+LD,
      * Microdata (inline) or RDFA.
      * 
-     * @param string $source A string representation of the file directory under
-     *                       which the HTML that is to be scanned is located.
-     * @param string $url    The original URL source of the file. Used to resolve
-     *                       relative paths in the markup data. The method does
-     *                       not access the URL in any way.
-     * @param bool $downloadImages  Use file_get_contents() to retreive and convert
-     *                              images found in the markup data to Base64. IF
-     *                              the image could not be retreived, the original
-     *                              URL is returned.
-     * @param int $downloadTimeout  Time in seconds, after which a download will be
-     *                              aborted.
-     * @param int $downloadSize Maximum size in bytes of images when downloading.
+     * @param string $source          A string representation of the file directory
+     *                                under which the HTML that is to be scanned is
+     *                                located.
+     * @param string $url             The original URL source of the file. Used to
+     *                                resolve relative paths in the markup data.
+     *                                The method does not access the URL in any way.
+     * @param bool   $downloadImages  Use file_get_contents() to retreive and convert
+     *                                images found in the markup data to Base64. IF
+     *                                the image could not be retreived, the original
+     *                                URL is returned.
+     * @param int    $downloadTimeout Time in seconds, after which a download will be
+     *                                aborted.
+     * @param int    $downloadSize    Maximum size in bytes of images when
+     *                                downloading.
      * 
      * @return string $result A JSON string containing any markup located in the
      * source. If the source contains multiple markup tags, multiple formats of
@@ -82,27 +91,36 @@ class MarkupUtil
         bool $downloadImages= true,
         int $downloadTimeout = 5,
         int $downloadSize = 500000
-        ) {
+    ) {
         $html = self::getHtmlFromFile($source);
 
-        return self::getJsonLdFromHtmlString($html, $url, $downloadImages, $downloadTimeout, $downloadSize);
+        return self::getJsonLdFromHtmlString(
+            $html,
+            $url,
+            $downloadImages,
+            $downloadTimeout,
+            $downloadSize
+        );
     }
 
     /**
      * Extract any Schema.org markup information found in the HTML string as JSON+LD,
      * Microdata (inline) or RDFA.
      * 
-     * @param string $html A string representation of the HTML file to be scanned.
-     * @param string $url  The original URL source of the file. Used to resolve
-     *                     relative paths in the markup data. The method does
-     *                     not access the URL in any way.
-     * @param bool $downloadImages  Use file_get_contents() to retreive and convert
-     *                              images found in the markup data to Base64. IF
-     *                              the image could not be retreived, the original
-     *                              URL is returned.
-     * @param int $downloadTimeout  Time in seconds, after which a download will be
-     *                              aborted.
-     * @param int $downloadSize Maximum size in bytes of images when downloading.
+     * @param string $html            A string representation of the HTML file to be
+     *                                scanned.
+     * @param string $url             The original URL source of the file. Used to
+     *                                resolve
+     *                                relative paths in the markup data. The method
+     *                                does not access the URL in any way.
+     * @param bool   $downloadImages  Use file_get_contents() to retreive and convert
+     *                                images found in the markup data to Base64. IF
+     *                                the image could not be retreived, the original
+     *                                URL is returned.
+     * @param int    $downloadTimeout Time in seconds, after which a download will be
+     *                                aborted.
+     * @param int    $downloadSize    Maximum size in bytes of images when
+     *                                downloading.
      * 
      * @return string $result A JSON string containing any markup located in the
      * source. If the source contains multiple markup tags, multiple formats of
@@ -115,7 +133,7 @@ class MarkupUtil
         bool $downloadImages= true,
         int $downloadTimeout = 5,
         int $downloadSize = 500000
-        ) {
+    ) {
         // TODO / For future reference: we might want to check the HTML source for
         // relevant substrings ("http://schema.org", "<aplication/ld+json>",
         // "itemscope", "vocab", etc.) before building the DomDocument or the
@@ -132,7 +150,12 @@ class MarkupUtil
 
         $items = $readerChain->read($domDocument, $url);
 
-        $jsonLd = self::convertItemArrayToJsonLd($items, $downloadImages, $downloadTimeout, $downloadSize);
+        $jsonLd = self::convertItemArrayToJsonLd(
+            $items,
+            $downloadImages,
+            $downloadTimeout,
+            $downloadSize
+        );
 
         return $jsonLd;
     }
@@ -176,19 +199,24 @@ class MarkupUtil
      * Converts an Item Array to a JSON String, either as a single JSON
      * object or a JSON Array.
      * 
-     * @param ?array $items An Array of Brick\StructuredData\Item objects.
-     * @param bool $downloadImages  Use file_get_contents() to retreive and convert
-     *                              images found in the markup data to Base64. IF
-     *                              the image could not be retreived, the original
-     *                              URL is returned.
-     * @param int $downloadTimeout  Time in seconds, after which a download will be
-     *                              aborted.
-     * @param int $downloadSize Maximum size in bytes of images when downloading.
+     * @param ?array $items           An Array of Brick\StructuredData\Item objects.
+     * @param bool   $downloadImages  Use file_get_contents() to retreive and convert
+     *                                images found in the markup data to Base64. IF
+     *                                the image could not be retreived, the original
+     *                                URL is returned.
+     * @param int    $downloadTimeout Time in seconds, after which a download will be
+     *                                aborted.
+     * @param int    $downloadSize    Maximum size in bytes of images when
+     *                                downloading.
      * 
      * @return string $result The array converted to a JSON string.
      */
-    protected static function convertItemArrayToJsonLd(?array $items, $downloadImages, $downloadTimeout, $downloadSize)
-    {
+    protected static function convertItemArrayToJsonLd(
+        ?array $items,
+        $downloadImages,
+        $downloadTimeout,
+        $downloadSize
+    ) {
         // The Brick/StructuredData Readers return their own custom Item arrays.
         // These can be written to JSON Strings using their writer.
         $writer = new JsonLdWriter($downloadImages, $downloadTimeout, $downloadSize);

--- a/tests/resources/jsonld-website.html
+++ b/tests/resources/jsonld-website.html
@@ -18,7 +18,7 @@
           "@type": "Organization",
           "name": "Example Publication"
         },
-        "image": "bananabread.png"
+        "image": "https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg?20240301091138"
     }
     </script>
     <div>

--- a/tests/unit/MarkupUtilTest.php
+++ b/tests/unit/MarkupUtilTest.php
@@ -97,6 +97,9 @@ class MarkupUtilTest extends TestCase
 
         $this->assertArrayHasKey("author", $this->result);
         $this->assertIsArray($this->result["author"]);
+
+        $this->assertArrayHasKey('image', $this->result);
+        $this->assertStringStartsWith('data:image/jpg;base64,/9j/4AAQSkZJRgABAQEASABIAAD', $this->result['image']);
     }
 
     public function testJsonLdFromArticleZeit(): void


### PR DESCRIPTION
This PR will add conversion of images stored as URLs to Base64 Data-URLs. This includes:

* Validating the URL
* Setting a timeout window
* Setting a maximum image size
* Finding out the mime type of the image
* Converting the image to a Base64 Data-URL

It will also add 3 new optional config parameters to the outward facing methods of `MarkupUtil.php`. These are:
* `downloadImages`
* `downloadTimeout`
* `downloadSize`

**Test Status:**
* `phpunit`: `success`